### PR TITLE
ALSA: usb-audio: Add Gustard U16/X26 to quirks for native DSD support

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1586,6 +1586,9 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
 	case USB_ID(0x1511, 0x0037): /* AURALiC VEGA */
 	case USB_ID(0x2522, 0x0012): /* LH Labs VI DAC Infinity */
 	case USB_ID(0x2772, 0x0230): /* Pro-Ject Pre Box S2 Digital */
+	
+	/* ESS based USB DACs/Interfaces */	
+	case USB_ID(0x292b, 0xc4b3): /* Gustard U16/X26 USB Interface */		
 		if (fp->altsetting == 2)
 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 		break;


### PR DESCRIPTION
Added ESS 8620 based USB Audio interface Native DSD support, including Gustard U16 interface and Gustard X26 DAC built in USB interface